### PR TITLE
Automation added to remove manual steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ In order to run the scripts, we will need to install ruby. Ruby comes pre-instal
 ### Downloading BibleGateway-to-Markdown.rb
 Follow the instructions to download and set up [jgclark's BibleGateway-to-Markdown](https://github.com/jgclark/BibleGateway-to-Markdown).
 
-Note: If you are cloning this repository with git please use the `--recurse-submodules` with git to download the submodules
-*`git clone --recurse-submodules https://github.com/joebuhlig/BibleGateway-to-Obsidian.git`
+**NOTE**: You don't need to download separate if you are cloning this repository git as it is a submodule. Please use the `--recurse-submodules` with git to download the submodules
+```
+git clone --recurse-submodules https://github.com/joebuhlig/BibleGateway-to-Obsidian.git
+```
 
 ## Usage
 
@@ -39,33 +41,19 @@ Open terminal. Use the following command to navigate to the folder in which both
 ### 2. Run the script
 Once you are in the directory, run `bash bg2obs.sh`. This will run the bash script.
 
-`NOTE`: In this directory, a folder called `ESV` with subfolders like `01 - Genesis`, `02 - Exodus` and so on will be created.
+**NOTE**: Update the `config.sh` with the text editor first if you would like to adjust any settings prior to executing the command. Default settings include:
+- Translation is `ESV`
+- Headers is `false` - *include headers*
+- Bold letters is `false` - *set the words of Jesus to bold*
+- Split verses is `true` - *splits the verses into separate folders for each chapter and files for each verse*
+- Master files is `true` - *creats a master file for each chapter folder (only available if split verses is `true`)
 
-Within the `bg2obs.sh` file you have the options to include headers and set the words of Jesus to bold. By default, both options are set to `false`.
+***WARNING**: During the execution of the script your clipboard will be unusable as it is used to capture the contents pulled from Bible Gateway*
 
-### 3. Format the text in a text editor
-We will need to format the output to work well in Obsidian.
-1. Open [Atom](https://atom.io/) (or the like).
-2. Open the `ESV` folder with `File > Add Project Folder…` (or `Shift + Command + O`
-3. Open project-wide search with `Shift + Command + F`
+### 3. (Optional) Rename Folders by Numerical Order
+Run `bash rename-folders.sh` to add book numbers to the folder for sorting.
 
-Next up we are going to run two [Regex](https://en.wikipedia.org/wiki/Regular_expression)-searches to find and replace in our whole project.
-1. Enable Regex. Click the `.*` Icon.
-2. Run the first search. This clears unnecessary headers:
-* Find: `#.*(#####\D[1]\D)`
-* Replace: `#$1`
-* file: `*.md`
-3. Run the second search. This formats verses into h6:
-* Find: `######\s([0-9]\s|[0-9][0-9]\s|[0-9][0-9][0-9]\s)`
-* Replace: `\n\nv$1`
-* file: `*.md`
-(Some crossreferences are sometimes still included, run `\<crossref intro.*crossref\>` to delete.)
-
-### 4. Split each virse to it's own file.
-
-1. Run `bash versesplit.sh` to split the chapters in to seprate verse files.
-2. Run `bash masterfiles.sh` to create the link file for each book. This only works if you split the files, do not run on it's own.
-3. (Optional) Run `bash rename-folders.sh` to add book numbers to the folder for sorting.
+- `NOTE`: With this option, the subfolders within your translation folder (ie. `ESV`) will be updated with sequential prefixes like `01 - Genesis`, `02 - Exodus` and so on.
 
 **There you go!** Now, just move the "ESV" folder into your Obsidian vault. You can use the provided `The Bible.md` file as an overview file. (Not setup with folder numbers)
 

--- a/bg2obs.sh
+++ b/bg2obs.sh
@@ -68,8 +68,17 @@ filename=${export_prefix}$export_number # Setting the filename
     text=$(ruby BibleGateway-to-Markdown/bg2md.rb -e -c -f -l -r -v "${translation}" ${book} ${chapter}) # This calls the 'bg2md_mod script'
   fi
 
+    # Remove unwanted headers from the text
+    text=$(echo $text | sed 's/^(.*?)v1/v1/') 
 
-  text=$(echo $text | sed 's/^(.*?)v1/v1/') # Deleting unwanted headers
+    # Remove Chapter Header
+    text=$(echo "$text" | sed 's/.*##### Chapter [0-9][0-9]* //g')
+
+    # Fix Verse Headers
+    text=$(echo "$text" | sed -E 's/###### ([0-9]+)/\nv\1 /g')
+
+    # Add line breaks
+    text=$(echo "$text" | awk '{gsub("v[0-9]","\\n\\n&")};1')
 
   # Formatting the title for markdown
   title="# ${book} ${chapter}"

--- a/bg2obs.sh
+++ b/bg2obs.sh
@@ -16,57 +16,60 @@
 # make sure to honour the copyright restrictions.
 #----------------------------------------------------------------------------------
 
-# OPTIONS
+# Source the config file
 source config.sh
- # Cycling through the book counter, setting which book and it's maxchapter
-  for ((book_counter=0; book_counter <= book_counter_max; book_counter++))
+
+# Loop through each book in the book array
+for ((book_counter=0; book_counter <= book_counter_max; book_counter++))
+do
+  # Get the current book name, max chapter and abbreviation
+  book=${bookarray[$book_counter]}
+  maxchapter=${lengtharray[$book_counter]}
+  abbreviation=${abbarray[$book_counter]}
+
+  # Loop through each chapter of the current book
+  for ((chapter=1; chapter <= maxchapter; chapter++))
   do
+    # Calculate the previous and next chapter
+    prev_chapter=$((chapter-1))
+    next_chapter=$((chapter+1))
 
-    book=${bookarray[$book_counter]}
-    maxchapter=${lengtharray[$book_counter]}
-    abbreviation=${abbarray[$book_counter]}
+    # Set the prefix of the filename
+    export_prefix="${book} "
 
-    for ((chapter=1; chapter <= maxchapter; chapter++))
-    do
+    # Set the chapter number for the filename
+    export_number=${chapter}
+    filename=${export_prefix}$export_number
 
-((prev_chapter=chapter-1)) # Counting the previous and next chapter for navigation
-((next_chapter=chapter+1))
+    # Calculate the filenames for the previous and next chapters
+    prev_file=${export_prefix}$prev_chapter
+    next_file=${export_prefix}$next_chapter
 
-# Exporting
-  export_prefix="${book} " # Setting the first half of the filename
+    # Calculate the navigation links
+    if [ ${maxchapter} -eq 1 ]; then
+      # For a book with only one chapter
+      navigation="[[${book}]]"
+    elif [ ${chapter} -eq ${maxchapter} ]; then
+      # For the last chapter of the book
+      navigation="[[${prev_file}|← ${book} ${prev_chapter}]] | [[${book}]]"
+    elif [ ${chapter} -eq 1 ]; then
+      # For the first chapter of the book
+      navigation="[[${book}]] | [[${next_file}|${book} ${next_chapter} →]]"
+    else
+      # For all other chapters
+      navigation="[[${prev_file}|← ${book} ${prev_chapter}]] | [[${book}]] | [[${next_file}|${book} ${next_chapter} →]]"
+    fi
 
-  export_number=${chapter}
-
-filename=${export_prefix}$export_number # Setting the filename
-
-
-  prev_file=${export_prefix}$prev_chapter # Naming previous and next files
-  next_file=${export_prefix}$next_chapter
-
-  # Formatting Navigation and omitting links that aren't necessary
-  if [ ${maxchapter} -eq 1 ]; then
-    # For a book that only has one chapter
-    navigation="[[${book}]]"
-  elif [ ${chapter} -eq ${maxchapter} ]; then
-    # If this is the last chapter of the book
-    navigation="[[${prev_file}|← ${book} ${prev_chapter}]] | [[${book}]]"
-  elif [ ${chapter} -eq 1 ]; then
-    # If this is the first chapter of the book
-    navigation="[[${book}]] | [[${next_file}|${book} ${next_chapter} →]]"
-  else
-    # Navigation for everything else
-    navigation="[[${prev_file}|← ${book} ${prev_chapter}]] | [[${book}]] | [[${next_file}|${book} ${next_chapter} →]]"
-  fi
-
-  if ${boldwords} -eq "true" && ${headers} -eq "false"; then
-    text=$(ruby BibleGateway-to-Markdown/bg2md.rb -e -c -b -f -l -r -v "${translation}" ${book} ${chapter}) # This calls the 'bg2md_mod script'
-  elif ${boldwords} -eq "true" && ${headers} -eq "true"; then
-    text=$(ruby BibleGateway-to-Markdown/bg2md.rb -c -b -f -l -r -v "${translation}" ${book} ${chapter}) # This calls the 'bg2md_mod script'
-  elif ${boldwords} -eq "false" && ${headers} -eq "true"; then
-    text=$(ruby BibleGateway-to-Markdown/bg2md.rb -e -c -f -l -r -v "${translation}" ${book} ${chapter}) # This calls the 'bg2md_mod script'
-  else
-    text=$(ruby BibleGateway-to-Markdown/bg2md.rb -e -c -f -l -r -v "${translation}" ${book} ${chapter}) # This calls the 'bg2md_mod script'
-  fi
+    # Choose the appropriate options for the conversion script based on `boldwords` and `headers`
+    if ${boldwords} == "true" && ${headers} == "false"; then
+      text=$(ruby BibleGateway-to-Markdown/bg2md.rb -e -c -b -f -l -r -v "${translation}" ${book} ${chapter})
+    elif ${boldwords} == "true" && ${headers} == "true"; then
+      text=$(ruby BibleGateway-to-Markdown/bg2md.rb -c -b -f -l -r -v "${translation}" ${book} ${chapter})
+    elif ${boldwords} == "false" && ${headers} == "true"; then
+      text=$(ruby BibleGateway-to-Markdown/bg2md.rb -e -c -f -l -r -v "${translation}" ${book} ${chapter})
+    else
+      text=$(ruby BibleGateway-to-Markdown/bg2md.rb -e -c -f -l -r -v "${translation}" ${book} ${chapter})
+    fi
 
     # Remove unwanted headers from the text
     text=$(echo $text | sed 's/^(.*?)v1/v1/') 
@@ -80,34 +83,31 @@ filename=${export_prefix}$export_number # Setting the filename
     # Add line breaks
     text=$(echo "$text" | awk '{gsub("v[0-9]","\\n\\n&")};1')
 
-  # Formatting the title for markdown
-  title="# ${book} ${chapter}"
+    # Formatting the title for markdown
+    title="# ${book} ${chapter}"
 
-  # Navigation format
-  export="${title}\n\n$navigation\n***\n\n$text\n\n***\n$navigation"
+    # Navigation format
+    export="${title}\n\n$navigation\n***\n\n$text\n\n***\n$navigation"
 
+    # Export
+    echo -e $text >> "$filename.md"
 
-  # Export
-  echo -e $text >> "$filename.md"
+    # Creating a folder
+    ((actual_num=book_counter+1)) # Proper number counting for the folder
 
-  # Creating a folder
+    if (( $actual_num < 10 )); then
+      #statements
+      actual_num="${actual_num}"
+    else
+      actual_num=$actual_num
+    fi
 
-  ((actual_num=book_counter+1)) # Proper number counting for the folder
+    folder_name="${book}" # Setting the folder name
 
-  if (( $actual_num < 10 )); then
-    #statements
-    actual_num="${actual_num}"
-  else
-    actual_num=$actual_num
-  fi
-
-  folder_name="${book}" # Setting the folder name
-
-  # Creating a folder for the book of the Bible it not existing, otherwise moving new file into existing folder
-  mkdir -p "./${translation}/${folder_name}"; mv "${filename}".md "${translation}/${folder_name}"
-
-
-done # End of the book exporting loop
+    # Creating a folder for the book of the Bible it not existing, otherwise moving new file into existing folder
+    mkdir -p "./${translation}/${folder_name}"; mv "${filename}".md "${translation}/${folder_name}"
+  
+  done # End of the book exporting loop
 
   # Create an overview file for each book of the Bible:
   overview_file="links: [[The Bible]]\n# ${book}\n\n[[${book} 1|Start Reading →]]"
@@ -115,7 +115,7 @@ done # End of the book exporting loop
   #mkdir -p ./Scripture ("${translation}")/"${folder_name}"; mv "$book.md" './Scripture ('"${translation}"')/'"${folder_name}"
   mv "$book.md" "${translation}/${folder_name}"
 
-  done
+done
 
   #----------------------------------------------------------------------------------
   # The Output of this text needs to be formatted slightly to fit with use in Obsidian

--- a/bg2obs.sh
+++ b/bg2obs.sh
@@ -117,15 +117,14 @@ do
 
 done
 
-  #----------------------------------------------------------------------------------
-  # The Output of this text needs to be formatted slightly to fit with use in Obsidian
-  # Enable Regex and run find and replace:
-    # *Clean up unwanted headers*
-      # Find: ^[\w\s]*(######)
-      # Replace: \n$1
-      # file: *.md
-    # Clean up verses
-      # Find: (######\sv\d)
-      # Replace: \n\n$1\n
-      # file: *.md
-  #----------------------------------------------------------------------------------
+# Split the verses into separate notes
+
+# Choose the appropriate options for the conversion script based on `boldwords` and `headers`
+if ${splitverses} == "true"; then
+  source versesplit.sh
+  
+  if ${masterfiles} == "true"; then
+    source masterfiles.sh
+  fi
+
+fi

--- a/config.sh
+++ b/config.sh
@@ -2,6 +2,8 @@
 translation="ESV" # Set translation
 boldwords="false" # Set 'true' for bolding words of Jesus
 headers="false" # Set 'true' for including editorial headers
+splitverses="true" # Set 'true' to split the verse into separate folders and notes afterwards
+masterfiles="true" # Set 'true' to generate a master file (only works if verses are split)
 
 book_counter=0 # Setting the counter to 0
 book_counter_max=66 # Setting the max amount to 66, since there are 66 books we want to import


### PR DESCRIPTION
With hours of help from ChatGPT I was able to remove the manual regex search/replace steps from the script. Along the way I learned enough to also automate the `splitverses.sh` and `masterfiles.sh` based on the `config.sh`. Based on these updates it made sense to update the `README.md` while I was at it. 

Prior to this I was getting issues with only a portion of books getting populated. There appeared to be a bug with `splitverses.sh` removing all the files within the folder. I traced this down to inconsistent results when running the regex search/replace steps over everything. Therefore this just seemed like the best approach forward. 

First time I've contributed publicly like this so hopefully I didn't miss anything.